### PR TITLE
Add JC filter plugin for parsing command outputs

### DIFF
--- a/plugins/filter/__init__.py
+++ b/plugins/filter/__init__.py
@@ -1,0 +1,23 @@
+# vim: ts=4:sw=4:sts=4:et:ft=python
+# -*- mode: python; tab-width: 4; indent-tabs-mode: nil; -*-
+#
+# GNU General Public License v3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Copyright (c) 2025 oØ.o (@o0-o)
+#
+# This file is part of the o0_o.posix Ansible Collection.
+
+"""Filter modules for the o0_o.posix collection."""
+
+from __future__ import annotations
+
+# Import JC filter module
+from ansible_collections.o0_o.posix.plugins.filter.jc import (
+    FilterModule as JcFilter,
+)
+
+__all__ = [
+    "JcFilter",
+]

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -20,7 +20,7 @@ name: jc
 version_added: "1.4.0"
 short_description: Parse command output using jc library
 description:
-  - Parse various command outputs into structured JSON data using the jc library
+  - Parse various command outputs into structured JSON data using jc library
   - Supports parsing output from common Unix commands like ps, df, mount, etc.
   - See U(https://github.com/kellyjonbrazil/jc) for list of supported parsers
 options:

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -1,0 +1,26 @@
+# vim: ts=4:sw=4:sts=4:et:ft=python
+# -*- mode: python; tab-width: 4; indent-tabs-mode: nil; -*-
+#
+# GNU General Public License v3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Copyright (c) 2025 oØ.o (@o0-o)
+#
+# This file is part of the o0_o.posix Ansible Collection.
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ansible_collections.o0_o.posix.plugins.filter_utils import JCBase
+
+
+class FilterModule(JCBase):
+    """Generic filter for parsing command output using jc."""
+
+    def filters(self) -> Dict[str, Any]:
+        """Return the filter functions."""
+        return {
+            "jc": self.jc,
+        }

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -15,6 +15,95 @@ from typing import Any, Dict
 
 from ansible_collections.o0_o.posix.plugins.filter_utils import JCBase
 
+DOCUMENTATION = r"""
+name: jc
+version_added: "1.4.0"
+short_description: Parse command output using jc library
+description:
+  - Parse various command outputs into structured JSON data using the jc library
+  - Supports parsing output from common Unix commands like ps, df, mount, etc.
+  - See U(https://github.com/kellyjonbrazil/jc) for list of supported parsers
+options:
+  _input:
+    description:
+      - Command output to parse - string, list of lines, or command result dict
+    type: raw
+    required: true
+  parser:
+    description:
+      - Name of the jc parser to use (e.g., 'ps', 'df', 'mount', 'uname')
+      - Run 'jc --help' or visit jc documentation for complete list
+    type: str
+    required: true
+  raw:
+    description:
+      - If True, return raw parsed output without post-processing
+      - Some parsers provide additional normalization when False
+    type: bool
+    default: false
+  quiet:
+    description:
+      - If True, suppress jc parsing warnings
+    type: bool
+    default: false
+requirements:
+  - jc (Python library)
+author:
+  - oØ.o (@o0-o)
+"""
+
+EXAMPLES = r"""
+# Parse ps aux output
+- name: Get process list
+  ansible.builtin.command:
+    cmd: ps aux
+  register: ps_result
+
+- name: Parse ps output
+  ansible.builtin.debug:
+    msg: "{{ ps_result.stdout | o0_o.posix.jc('ps') }}"
+
+# Parse df output
+- name: Get filesystem info
+  ansible.builtin.command:
+    cmd: df -h
+  register: df_result
+
+- name: Parse df output with raw format
+  ansible.builtin.debug:
+    msg: "{{ df_result | o0_o.posix.jc('df', raw=true) }}"
+
+# Parse mount output
+- name: Get mount points
+  ansible.builtin.command:
+    cmd: mount
+  register: mount_result
+
+- name: Parse mount output quietly
+  ansible.builtin.debug:
+    msg: "{{ mount_result.stdout_lines | o0_o.posix.jc('mount', quiet=true) }}"
+"""
+
+RETURN = r"""
+_output:
+  description:
+    - Parsed data structure varies based on the parser used
+    - Most parsers return a list of dictionaries
+    - Some parsers return a single dictionary
+  type: raw
+  returned: success
+  sample: |
+    [
+      {
+        "user": "root",
+        "pid": 1,
+        "cpu_percent": 0.0,
+        "mem_percent": 0.1,
+        "command": "/sbin/init"
+      }
+    ]
+"""
+
 
 class FilterModule(JCBase):
     """Generic filter for parsing command output using jc."""

--- a/plugins/filter_utils/__init__.py
+++ b/plugins/filter_utils/__init__.py
@@ -1,0 +1,18 @@
+# vim: ts=4:sw=4:sts=4:et:ft=python
+# -*- mode: python; tab-width: 4; indent-tabs-mode: nil; -*-
+#
+# GNU General Public License v3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Copyright (c) 2025 oØ.o (@o0-o)
+#
+# This file is part of the o0_o.posix Ansible Collection.
+
+"""Filter utility classes for the o0_o.posix collection."""
+
+from __future__ import annotations
+
+from ansible_collections.o0_o.posix.plugins.filter_utils.jc_base import JCBase
+
+__all__ = ["JCBase"]

--- a/plugins/filter_utils/jc_base.py
+++ b/plugins/filter_utils/jc_base.py
@@ -1,0 +1,109 @@
+# vim: ts=4:sw=4:sts=4:et:ft=python
+# -*- mode: python; tab-width: 4; indent-tabs-mode: nil; -*-
+#
+# GNU General Public License v3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Copyright (c) 2025 oØ.o (@o0-o)
+#
+# This file is part of the o0_o.posix Ansible Collection.
+
+"""JC base class for jc-based filters."""
+
+from __future__ import annotations
+
+import traceback
+from typing import Any, Dict, List, Union
+
+from ansible.errors import AnsibleFilterError
+
+try:
+    import jc
+
+    HAS_JC = True
+    JC_IMPORT_ERROR = None
+except ImportError:
+    HAS_JC = False
+    JC_IMPORT_ERROR = traceback.format_exc()
+
+
+class JCBase:
+    """Base class for filters that use the jc library for parsing."""
+
+    def jc(
+        self,
+        data: Union[str, List[str], Dict[str, Any]],
+        parser: str,
+        raw: bool = False,
+        quiet: bool = False,
+    ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+        """Parse command output using jc library.
+
+        :param data: Output from command - string, list of lines,
+            or command result
+        :param parser: Name of the jc parser to use (e.g., 'mount',
+            'df', 'ps')
+        :param raw: If True, return raw parsed output without
+            post-processing
+        :param quiet: If True, suppress jc parsing warnings
+        :returns: Parsed data structure (list or dict depending on
+            parser)
+        :raises AnsibleFilterError: If jc is not available or parsing
+            fails
+        """
+        # Check for jc availability
+        if not HAS_JC:
+            raise AnsibleFilterError(
+                "The jc library is required for jc-based filters. "
+                "Install it with: pip install jc",
+                orig_exc=JC_IMPORT_ERROR,
+            )
+
+        # Check validity of the parser name
+        jc_parsers = sorted(jc.parser_mod_list())
+        if parser not in jc_parsers:
+            raise AnsibleFilterError(
+                f"jc parser '{parser}' not found. "
+                f"Available parsers: {', '.join(jc_parsers)}"
+            )
+
+        # Extract raw output
+        raw_output = self._extract_output(data)
+
+        try:
+            # Parse using jc library
+            return jc.parse(parser, raw_output, raw=raw, quiet=quiet)
+        except Exception as e:
+            # jc raises various exceptions, catch them all
+            raise AnsibleFilterError(f"Error parsing {parser}: {e}")
+
+    def _extract_output(self, data: Union[str, List[str], Dict[str, Any]]) -> str:
+        """Extract raw string output from various input formats.
+
+        :param data: Input data in various formats
+        :returns: Raw string output
+        """
+        if isinstance(data, dict):
+            return data.get("stdout", "")
+        elif isinstance(data, str):
+            return data
+        elif isinstance(data, list):
+            return "\n".join(data)
+        elif data is None:
+            return ""
+        else:
+            return ""
+
+    def parse_command(
+        self, data: Union[str, List[str], Dict[str, Any]], parser: str
+    ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+        """Parse command output using the specified jc parser.
+
+        This is a convenience method for subclasses.
+
+        :param data: Output from command
+        :param parser: Name of the jc parser to use
+        :returns: Parsed data structure
+        """
+        return self.jc(data, parser)

--- a/plugins/filter_utils/jc_base.py
+++ b/plugins/filter_utils/jc_base.py
@@ -78,7 +78,9 @@ class JCBase:
             # jc raises various exceptions, catch them all
             raise AnsibleFilterError(f"Error parsing {parser}: {e}")
 
-    def _extract_output(self, data: Union[str, List[str], Dict[str, Any]]) -> str:
+    def _extract_output(
+        self, data: Union[str, List[str], Dict[str, Any]]
+    ) -> str:
         """Extract raw string output from various input formats.
 
         :param data: Input data in various formats

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,0 +1,2 @@
+# Integration test requirements for o0_o.posix collection
+jc>=1.25.0

--- a/tests/integration/targets/filter_jc/tasks/main.yml
+++ b/tests/integration/targets/filter_jc/tasks/main.yml
@@ -1,0 +1,131 @@
+# vim: ts=2:sw=2:sts=2:et:ft=yaml.ansible
+# -*- mode: yaml; yaml-indent-offset: 2; indent-tabs-mode: nil; -*-
+---
+# GNU General Public License v3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Copyright (c) 2025 oØ.o (@o0-o)
+#
+# This file is part of the o0_o.posix Ansible Collection.
+
+- name: Test JC filter with string input (stdout)
+  block:
+    - name: Get uname output
+      ansible.builtin.command:
+        cmd: uname -a
+      register: uname_output_reg
+
+    - name: Parse using stdout string
+      ansible.builtin.set_fact:
+        parsed_from_stdout: >-
+          {{ uname_output_reg['stdout'] | o0_o.posix.jc('uname') }}
+
+    - name: Assert stdout parsing worked
+      ansible.builtin.assert:
+        that:
+          - parsed_from_stdout is defined
+          - parsed_from_stdout is mapping
+          - parsed_from_stdout['kernel_name'] is defined
+
+- name: Test JC filter with list input (stdout_lines)
+  block:
+    - name: Parse using stdout_lines list
+      ansible.builtin.set_fact:
+        parsed_from_lines: >-
+          {{ uname_output_reg['stdout_lines'] | o0_o.posix.jc('uname') }}
+
+    - name: Assert stdout_lines parsing worked
+      ansible.builtin.assert:
+        that:
+          - parsed_from_lines is defined
+          - parsed_from_lines is mapping
+          - parsed_from_lines['kernel_name'] is defined
+
+- name: Test JC filter with whole command result dict
+  block:
+    - name: Parse using whole registered variable
+      ansible.builtin.set_fact:
+        parsed_from_dict: "{{ uname_output_reg | o0_o.posix.jc('uname') }}"
+
+    - name: Assert dict parsing worked
+      ansible.builtin.assert:
+        that:
+          - parsed_from_dict is defined
+          - parsed_from_dict is mapping
+          - parsed_from_dict['kernel_name'] is defined
+
+- name: Test all three input methods produce same result
+  ansible.builtin.assert:
+    that:
+      - parsed_from_stdout == parsed_from_lines
+      - parsed_from_stdout == parsed_from_dict
+    fail_msg: "Different input methods should produce identical results"
+
+- name: Test JC filter with empty inputs
+  block:
+    - name: Parse empty string
+      ansible.builtin.set_fact:
+        empty_string_result: "{{ '' | o0_o.posix.jc('ls') }}"
+
+    - name: Parse empty list
+      ansible.builtin.set_fact:
+        empty_list_result: "{{ [] | o0_o.posix.jc('ls') }}"
+
+    - name: Parse dict with empty stdout
+      ansible.builtin.set_fact:
+        empty_dict_result: >-
+          {{ {'stdout': '', 'rc': 0} | o0_o.posix.jc('ls') }}
+
+    - name: Assert empty inputs return empty results
+      ansible.builtin.assert:
+        that:
+          - empty_string_result == []
+          - empty_list_result == []
+          - empty_dict_result == []
+
+- name: 'Fail: Test JC filter with invalid parser'
+  block:
+
+    - name: Try to use invalid parser
+      ansible.builtin.set_fact:
+        invalid_result: >-
+          {{ 'test data' | o0_o.posix.jc('invalid_parser_xyz') }}
+
+  rescue:
+
+    - name: Assert invalid parser raised an error
+      ansible.builtin.assert:
+        that:
+          - ansible_failed_result is defined
+          - "'invalid_parser_xyz' in ansible_failed_result.msg"
+
+- name: 'Fail: Test JC filter with wrong variable type'
+  block:
+
+    - name: Try to parse a number
+      ansible.builtin.set_fact:
+        number_result: "{{ 12345 | o0_o.posix.jc('ls') }}"
+
+  rescue:
+
+    - name: Verify number input was handled
+      ansible.builtin.assert:
+        that:
+          # Either it failed or returned empty list
+          - ansible_failed_result is defined or number_result == []
+
+- name: Test that filter is available and callable
+  block:
+    - name: Verify filter exists in collection
+      ansible.builtin.set_fact:
+        # Use a complete uname output
+        filter_test: >-
+          {{ 'Linux host 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux'
+             | o0_o.posix.jc('uname') }}
+
+    - name: Assert filter was callable
+      ansible.builtin.assert:
+        that:
+          - filter_test is defined
+          - filter_test is mapping

--- a/tests/unit/plugins/filter/test_jc.py
+++ b/tests/unit/plugins/filter/test_jc.py
@@ -1,0 +1,164 @@
+# vim: ts=4:sw=4:sts=4:et:ft=python
+# -*- mode: python; tab-width: 4; indent-tabs-mode: nil; -*-
+#
+# GNU General Public License v3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Copyright (c) 2025 oØ.o (@o0-o)
+#
+# This file is part of the o0_o.posix Ansible Collection.
+
+"""Unit tests for JC filter plugin."""
+
+from __future__ import annotations
+
+import pytest
+
+from ansible.errors import AnsibleFilterError
+from ansible_collections.o0_o.posix.plugins.filter.jc import FilterModule
+from ansible_collections.o0_o.posix.plugins.filter_utils import JCBase
+
+
+class TestJCBase:
+    """Test JCBase utility class methods."""
+
+    @pytest.fixture
+    def jc_base(self):
+        """Create a JCBase instance for testing."""
+        return JCBase()
+
+    @pytest.mark.parametrize(
+        "input_data,expected",
+        [
+            # String input returns as-is
+            ("simple string", "simple string"),
+            ("", ""),
+            # List input gets joined with newlines
+            (["line1", "line2"], "line1\nline2"),
+            (["single line"], "single line"),
+            ([" line1 ", " line2 "], " line1 \n line2 "),
+            ([], ""),
+            # Dict input extracts stdout only
+            ({"stdout": "test output"}, "test output"),
+            ({"stdout_lines": ["line1", "line2"]}, ""),  # Only stdout is used
+            (
+                {"stdout": "stdout wins", "stdout_lines": ["ignored"]},
+                "stdout wins",
+            ),
+            ({"rc": 0}, ""),
+            ({}, ""),
+            # Invalid types return empty string
+            (42, ""),
+            (3.14, ""),
+            (None, ""),
+            (True, ""),
+            (object(), ""),
+        ],
+    )
+    def test_extract_output(self, jc_base, input_data, expected):
+        """Test _extract_output handles all input types correctly."""
+        result = jc_base._extract_output(input_data)
+        assert result == expected
+
+    def test_jc_method_calls_jc_library(self, jc_base):
+        """Test that jc method successfully calls the jc library."""
+        # Use a complete uname -a output
+        uname_output = "Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux"
+        result = jc_base.jc(uname_output, "uname")
+
+        # We just verify it returns a dict and has expected structure
+        assert isinstance(result, dict)
+        assert "kernel_name" in result
+        assert result["kernel_name"] == "Linux"
+
+    def test_jc_invalid_parser_raises_error(self, jc_base):
+        """Test that invalid parser name raises AnsibleFilterError."""
+        with pytest.raises(AnsibleFilterError) as exc_info:
+            jc_base.jc("test data", "invalid_parser_name_xyz")
+
+        assert "jc parser 'invalid_parser_name_xyz' not found" in str(exc_info.value)
+
+    def test_parse_command_calls_jc(self, jc_base):
+        """Test that parse_command is a working alias for jc."""
+        uname_output = "Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux"
+        result1 = jc_base.jc(uname_output, "uname")
+        result2 = jc_base.parse_command(uname_output, "uname")
+
+        assert result1 == result2
+
+    def test_jc_raw_parameter(self, jc_base):
+        """Test that raw parameter is passed to jc.parse."""
+        # The raw parameter affects jc's post-processing
+        # We just verify it doesn't error
+        uname_output = "Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux"
+        result = jc_base.jc(uname_output, "uname", raw=True)
+        assert isinstance(result, dict)
+
+    def test_jc_quiet_parameter(self, jc_base):
+        """Test that quiet parameter is passed to jc.parse."""
+        # The quiet parameter suppresses warnings
+        # We just verify it doesn't error
+        uname_output = "Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux"
+        result = jc_base.jc(uname_output, "uname", quiet=True)
+        assert isinstance(result, dict)
+
+
+class TestFilterModule:
+    """Test FilterModule class."""
+
+    @pytest.fixture
+    def filter_module(self):
+        """Create a FilterModule instance for testing."""
+        return FilterModule()
+
+    def test_filters_returns_correct_dict(self, filter_module):
+        """Test that filters() returns a dict with 'jc' key."""
+        filters = filter_module.filters()
+
+        assert isinstance(filters, dict)
+        assert "jc" in filters
+        assert callable(filters["jc"])
+        # The filter should be the jc method from JCBase
+        assert filters["jc"].__name__ == "jc"
+
+    def test_filter_inherits_from_jcbase(self, filter_module):
+        """Test that FilterModule properly inherits from JCBase."""
+        assert isinstance(filter_module, JCBase)
+        assert hasattr(filter_module, "jc")
+        assert hasattr(filter_module, "_extract_output")
+        assert hasattr(filter_module, "parse_command")
+
+    @pytest.mark.parametrize(
+        "input_data",
+        [
+            # Test different input formats are handled
+            ("Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux"),
+            (["Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux"]),
+            ({"stdout": ("Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux")}),
+        ],
+    )
+    def test_jc_filter_processes_input_types(self, filter_module, input_data):
+        """Test that the filter processes different input types."""
+        jc_filter = filter_module.filters()["jc"]
+
+        # Don't test parsing result, just that it processes w/o error
+        result = jc_filter(input_data, "uname")
+        assert result is not None
+        assert isinstance(result, dict)
+
+    def test_jc_filter_with_empty_inputs(self, filter_module):
+        """Test filter handles empty inputs gracefully."""
+        jc_filter = filter_module.filters()["jc"]
+
+        # Empty string should parse to empty result
+        result = jc_filter("", "ls")
+        assert result == []
+
+        # Empty list should parse to empty result
+        result = jc_filter([], "ls")
+        assert result == []
+
+        # Dict with empty stdout should parse to empty result
+        result = jc_filter({"stdout": ""}, "ls")
+        assert result == []

--- a/tests/unit/plugins/filter/test_jc.py
+++ b/tests/unit/plugins/filter/test_jc.py
@@ -77,7 +77,9 @@ class TestJCBase:
         with pytest.raises(AnsibleFilterError) as exc_info:
             jc_base.jc("test data", "invalid_parser_name_xyz")
 
-        assert "jc parser 'invalid_parser_name_xyz' not found" in str(exc_info.value)
+        assert "jc parser 'invalid_parser_name_xyz' not found" in str(
+            exc_info.value
+        )
 
     def test_parse_command_calls_jc(self, jc_base):
         """Test that parse_command is a working alias for jc."""
@@ -135,7 +137,13 @@ class TestFilterModule:
             # Test different input formats are handled
             ("Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux"),
             (["Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux"]),
-            ({"stdout": ("Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux")}),
+            (
+                {
+                    "stdout": (
+                        "Linux hostname 5.10.0 #1 SMP PREEMPT x86_64 GNU/Linux"
+                    )
+                }
+            ),
         ],
     )
     def test_jc_filter_processes_input_types(self, filter_module, input_data):

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,2 @@
+# Unit test requirements for o0_o.posix collection
+jc>=1.25.0


### PR DESCRIPTION
## Summary
- Add jc filter plugin that wraps the JC library for parsing command outputs
- Add JCBase utility class for consistent input handling and error management
- Add comprehensive test coverage with focused tests on our code

## Description
This PR adds a new filter plugin `o0_o.posix.jc` that leverages the JC library to parse various command outputs into structured data. The filter intelligently handles different input formats (stdout, stdout_lines, or full command result dictionaries) and provides consistent error handling.

## Key Components
- `plugins/filter/jc.py` - Main filter plugin
- `plugins/filter_utils/jc_base.py` - JCBase utility class for input extraction and JC library interaction
- Comprehensive unit tests focusing on our code's functionality
- Integration tests verifying filter mechanics

## Testing
- All sanity tests passing
- 27 unit tests passing (Python 3.11, 3.12, 3.13)
- Integration tests passing with all input format variations tested

## Code Quality
- Formatted with black (79 char line limit)
- Validated with flake8 (72 char limit for docstrings/comments)
- YAML files conform to 79 char line limit

## Usage Example
```yaml
- name: Parse command output with JC
  set_fact:
    parsed_output: "{{ command_result | o0_o.posix.jc('uname') }}"
```

🤖 Generated with [Claude Code](https://claude.ai/code)